### PR TITLE
画像保存先設定　本番環境: S3ストレージ,  開発環境: public/uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore image file.
+public/uploads/*
+spec/fixtures/

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -2,4 +2,6 @@ class Photo < ApplicationRecord
   belongs_to :product
 
   validates :image, presence: true
+
+  mount_uploader :image, ImageUploader
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,4 +16,6 @@ class User < ApplicationRecord
   validates :nickname, :email, presence: true, uniqueness: true
   validates :tel, uniqueness: true
   validates :password, presence: true, length: { minimum: 7 }
+
+  mount_uploader :image, ImageUploader
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,51 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::MiniMagick
+
+  process resize_to_fit: [800, 800]
+  # Choose what kind of storage to use for this uploader:
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+  end
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,17 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+  config.storage = :fog
+  config.fog_provider = 'fog/aws'
+  config.fog_credentials = {
+    provider: 'AWS',
+    aws_access_key_id: Rails.application.credentials.aws[:access_key_id],
+    aws_secret_access_key: Rails.application.credentials.aws[:secret_access_key],
+    region: 'ap-northeast-1'
+  }
+
+  config.fog_directory  = 'mercari-66a'
+  config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/mercari-66a'
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,11 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+User.create!(
+  nickname: "hoge",
+  email: 'hoge@hoge',
+  password: 'hogehoge',
+  last_name: "山田",
+  first_name: "太郎",
+  last_name_kana: "ヤマダ",
+  first_name_kana: "タロウ",
+  birthday: "1990-07-02",
+  tel: "123456789",
+)


### PR DESCRIPTION
# What
- carrierwaveを導入した
- S3ストレージを作成し、紐づけた
- 本番環境ではS3ストレージへ、開発環境ではpublic/uploadsへ画像が保存されるように設定をした
- 開発環境でpublic/uploadsに画像が保存されることを確認した
- AWSのキーはcredentials.ymlに記載済

# Why
- 開発環境では全員が投稿した画像を見れるようにするため

画像投稿時のGIF
https://gyazo.com/8e1e713dc0dcb27780e96845ca0dea5a