### PR TITLE
Registrations/addressの変更

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -11,7 +11,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create
     @user = User.new(sign_up_params)
     @user.birthday = birthday_params
-    binding.pry
     unless @user.valid?
       flash.now[:alert] = @user.errors.full_messages
       render :new and return
@@ -71,7 +70,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def address_params
-    params.require(:address).permit(:postal_code, :prefecture, :city, :street, :building)
+    params.require(:address).permit(:postal_code, :prefecture, :city, :street, :building).merge(prefecture: params[:prefecture])
   end
 
   def card_params

--- a/app/views/users/registrations/address.html.haml
+++ b/app/views/users/registrations/address.html.haml
@@ -1,7 +1,7 @@
 .signup-wrapper
   .address-header
     %h1.address-header__logo
-      = link_to "#"do 
+      = link_to "/" do 
         = image_tag "fmarket_logo_white.svg"
     %nav.step-barfive
       %ol.clearfix
@@ -29,31 +29,32 @@
             .admin-address__form__coupon
               .admin-address__form__coupon__input
                 = form.label :name,"お名前" ,class:"name"
-                %a.red 必要
-                = form.text_field :last_name, required: true, class: "form_address",placeholder:"例）山田"
-                = form.text_field :first_name, required: true, class: "form_address",placeholder:"例）綾"
+                %a.red 必須
+                = form.text_field :last_name, required: true, class: "form_address", value: @user.last_name
+                = form.text_field :first_name, required: true, class: "form_address",value: @user.first_name
                 %br/
                 %br/
                 %br/
               .admin-address__form__coupon__input
                 = form.label :name,"お名前カナ" ,class:"name"
-                %a.red 必要
-                = form.text_field :last_name_kana, required: true, class: "form_address",placeholder:"例）ヤマダ"
-                = form.text_field :first_name_kana, required: true, class: "form_address",placeholder:"例）アヤ"
+                %a.red 必須
+                = form.text_field :last_name_kana, required: true, class: "form_address", value: @user.last_name_kana
+                = form.text_field :first_name_kana, required: true, class: "form_address", value: @user.first_name_kana
                 %br/
                 %br/
                 %br/
               .admin-address__form__coupon__input
                 = form.label :postal_code,"郵便番号" ,class:"name"
-                %a.red 必要
+                %a.red 必須
                 = form.text_field :postal_code, required: true, class: "form_address",placeholder:"例）123-0000"
                 %br/
                 %br/
                 %br/
               .admin-address__form__coupon__input
                 = form.label :prefecture,"都道府県" ,class:"name"
-                %a.red 必要
-                %select.form_address_prefecture{:name => "month" }
+                %a.red 必須
+                %select.form_address_prefecture{name: "prefecture"
+                 }
                   %option{:value => "1"} 北海道
                   %option{:value => "2"} 青森県
                   %option{:value => "3"} 岩手県
@@ -62,29 +63,29 @@
                 %br/
               .admin-address__form__coupon__input
                 = form.label :city,"市区町村" ,class:"name"
-                %a.red 必要
+                %a.red 必須
                 = form.text_field :city, required: true, class: "form_address",placeholder:"例）横浜市緑区"
                 %br/
                 %br/
                 %br/
               .admin-address__form__coupon__input
                 = form.label :street,"番地" ,class:"name"
-                %a.red 必要
+                %a.red 必須
                 = form.text_field :street, required: true, class: "form_address",placeholder:"例）青山1-1-1"
                 %br/
                 %br/
                 %br/
               .admin-address__form__coupon__input
                 = form.label :building,"建物名" ,class:"name"
-                %a.gray 必要
-                = form.text_field :building, required: true, class: "form_address",placeholder:"例）MatudaBuilding 103"
+                %a.gray 任意
+                = form.text_field :building, class: "form_address",placeholder:"例）MatudaBuilding 103"
                 %br/
                 %br/
                 %br/
               .admin-address__form__coupon__input
                 = form.label :tel,"電話番号" ,class:"name"
-                %a.gray 必要
-                = form.text_field :tel, required: true, class: "form_address",placeholder:"例）090-5555-7777"
+                %a.gray 任意
+                = form.text_field :tel, class: "form_address",placeholder:"例）090-5555-7777"
                 %br/
                 %br/
                 %br/

--- a/db/migrate/20200113093628_change_column_to_address.rb
+++ b/db/migrate/20200113093628_change_column_to_address.rb
@@ -1,0 +1,9 @@
+class ChangeColumnToAddress < ActiveRecord::Migration[5.2]
+  def up
+    change_column :addresses, :building, :string, null: true
+  end
+
+  def down
+    change_column :addresses, :building, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_12_014105) do
+ActiveRecord::Schema.define(version: 2020_01_13_093628) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2020_01_12_014105) do
     t.integer "prefecture", null: false
     t.string "city", null: false
     t.string "street", null: false
-    t.string "building", null: false
+    t.string "building"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
# What
- 必要の文字を必須、任意に書き換えた
- paramsでprefectureを受け取れるように修正した
- 入力内容が適切に受け取れて、次のページに遷移できることを確認した
- buildingカラムのnull: falseをnull: trueにした

# Why
- ユーザー登録する時に適切に情報を受け取れるようにする必要があるため
- buildingカラムは任意だったため