### PR TITLE
都道府県のenumを使った選択への変更

### DIFF
--- a/app/assets/stylesheets/users/registrations/address.scss
+++ b/app/assets/stylesheets/users/registrations/address.scss
@@ -259,3 +259,9 @@
     }
   }       
 }
+
+.prefecture-select {
+  height: 50px;
+  width: 100%;
+  opacity: 0.5;
+}

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -70,7 +70,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def address_params
-    params.permit(:postal_code, :city, :street, :building).merge(prefecture: params[:prefecture].to_i)
+    params.required(:address).permit(:postal_code, :city, :street, :building).merge(prefecture: params[:address][:prefecture].to_i)
   end
 
   def card_params

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -70,7 +70,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def address_params
-    params.require(:address).permit(:postal_code, :prefecture, :city, :street, :building).merge(prefecture: params[:prefecture])
+    params.permit(:postal_code, :city, :street, :building).merge(prefecture: params[:prefecture].to_i)
   end
 
   def card_params

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,5 +1,16 @@
 class Address < ApplicationRecord
   belongs_to :user, optional: true
 
-  validates :postal_code, :prefecture, :city, :street, :building, presence: true
+  validates :postal_code, :prefecture, :city, :street, presence: true
+
+  enum prefecture: {
+    北海道:1,青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,
+    茨城県:8,栃木県:9,群馬県:10,埼玉県:11,千葉県:12,東京都:13,神奈川県:14,
+    新潟県:15,富山県:16,石川県:17,福井県:18,山梨県:19,長野県:20,
+    岐阜県:21,静岡県:22,愛知県:23,三重県:24,
+    滋賀県:25,京都府:26,大阪府:27,兵庫県:28,奈良県:29,和歌山県:30,
+    鳥取県:31,島根県:32,岡山県:33,広島県:34,山口県:35,
+    徳島県:36,香川県:37,愛媛県:38,高知県:39,
+    福岡県:40,佐賀県:41,長崎県:42,熊本県:43,大分県:44,宮崎県:45,鹿児島県:46,沖縄県:47,その他:48
+  }
 end

--- a/app/views/users/registrations/address.html.haml
+++ b/app/views/users/registrations/address.html.haml
@@ -53,7 +53,8 @@
               .admin-address__form__coupon__input
                 = form.label :prefecture,"都道府県" ,class:"name"
                 %a.red 必須
-                = form.select :prefecture, options_for_select(Address.prefectures), {prompt: "選択してください"}
+                %br/
+                = form.select :prefecture, options_for_select(Address.prefectures), {prompt: "選択してください"}, class: "prefecture-select"
                 %br/
                 %br/
                 %br/

--- a/app/views/users/registrations/address.html.haml
+++ b/app/views/users/registrations/address.html.haml
@@ -53,10 +53,7 @@
               .admin-address__form__coupon__input
                 = form.label :prefecture,"都道府県" ,class:"name"
                 %a.red 必須
-                %select.form_address_prefecture{name: "prefecture"}
-                  %option{:value => "1"} 北海道
-                  %option{:value => "2"} 青森県
-                  %option{:value => "3"} 岩手県
+                = form.select :prefecture, options_for_select(Address.prefectures), {prompt: "選択してください"}
                 %br/
                 %br/
                 %br/


### PR DESCRIPTION
# What
- 都道府県をenumを使って、選択ボックスで選択できるようにした
- 受け取った値はparamsでは文字列の数字("1"など)になっていたため、数値型に変更した

# Why
- わざわざテーブルを用意しなくても、選択ボックスで選択できるようにするため