### PR TITLE
商品の写真表示機能 + 出品ボタンの仕様変更

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -86,7 +86,7 @@ class ProductsController < ApplicationController
   private
 
   def product_params
-    params.require(:product).permit(:name, :description, photos_attributes: [:image]).merge(user_id: current_user.id, category_id: params[:product][:category_id].to_i, brand_id: params[:product][:brand_id].to_i, size: params[:product][:size].to_i, condition: params[:product][:condition].to_i, shipping_charge: params[:product][:shipping_charge].to_i, shipping_method: params[:product][:shippig_method].to_i, shipping_prefecture: params[:product][:shipping_prefecture].to_i, shipping_days: params[:product][:shipping_days].to_i, brand_id: params[:product][:brand_id].to_i, price: params[:product][:price].to_i, progress: params[:product][:progress].to_i)
+    params.require(:product).permit(:name, :description, photos_attributes: [:image]).merge(user_id: current_user.id, category_id: params[:product][:category_id].to_i, brand_id: params[:product][:brand_id].to_i, size: params[:product][:size].to_i, condition: params[:product][:condition].to_i, shipping_charge: params[:product][:shipping_charge].to_i, shipping_method: params[:product][:shipping_method].to_i, shipping_prefecture: params[:product][:shipping_prefecture].to_i, shipping_days: params[:product][:shipping_days].to_i, brand_id: params[:product][:brand_id].to_i, price: params[:product][:price].to_i, progress: params[:product][:progress].to_i)
 
 
   end

--- a/app/views/products/_header.html.haml
+++ b/app/views/products/_header.html.haml
@@ -45,3 +45,5 @@
               =link_to "新規会員登録", new_user_path, class: 'new_user'
             %li.bottme_menu
               =link_to "ログイン", user_session_path, class: 'log_in'
+
+= render partial: "products/producte"

--- a/app/views/products/_producte.html.haml
+++ b/app/views/products/_producte.html.haml
@@ -1,0 +1,5 @@
+.producte
+  = link_to new_product_path do
+    .producte_now
+      .producte_text 出品
+      = icon('fas', 'camera', class: 'camera')

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -195,11 +195,7 @@
 
 = render partial: 'footer'
 
-.producte
-  = link_to new_product_path do
-    .producte_now
-      .producte_text 出品
-      = icon('fas', 'camera', class: 'camera')
+
 
 
 

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -38,7 +38,7 @@
           =link_to product_path(lady.id) ,class: "new_item" do
             .item_text 
               =lady.name
-            = image_tag "inu.jpg",class: "item_pic", alt: "販売写真"
+            = image_tag lady.photos.first.image.to_s,class: "item_pic", alt: "販売写真"
             %span{href:  "#",class: "price",id:"text_price"} 
               =price_split(lady.price)
 
@@ -57,7 +57,7 @@
           =link_to product_path(men.id) ,class: "new_item" do
             .item_text 
               =men.name
-            = image_tag "inu.jpg",class: "item_pic", alt: "販売写真"
+            = image_tag men.photos.first.image.to_s,class: "item_pic", alt: "販売写真"
             %span{href:  "#",class: "price",id:"text_price"} 
               =price_split(men.price)
 
@@ -77,7 +77,7 @@
           =link_to product_path(appliance.id) ,class: "new_item" do
             .item_text 
               =appliance.name
-            = image_tag "inu.jpg",class: "item_pic", alt: "販売写真"
+            = image_tag appliance.photos.first.image.to_s,class: "item_pic", alt: "販売写真"
             %span{href:  "#",class: "price",id:"text_price"} 
               =price_split(appliance.price)
 
@@ -97,7 +97,7 @@
           =link_to product_path(toy.id) ,class: "new_item" do
             .item_text 
               =toy.name
-            = image_tag "inu.jpg",class: "item_pic", alt: "販売写真"
+            = image_tag toy.photos.first.image.to_s,class: "item_pic", alt: "販売写真"
             %span{href:  "#",class: "price",id:"text_price"} 
               =price_split(toy.price)
 
@@ -126,7 +126,7 @@
           =link_to product_path(chanel.id) ,class: "new_item" do
             .item_text 
               =chanel.name
-            = image_tag "inu.jpg",class: "item_pic", alt: "販売写真"
+            = image_tag chanel.photos.first.image.to_s,class: "item_pic", alt: "販売写真"
             %span{href:  "#",class: "price",id:"text_price"} 
               =price_split(chanel.price)
 
@@ -145,7 +145,7 @@
           =link_to product_path(coach.id) ,class: "new_item" do
             .item_text 
               =coach.name
-            = image_tag "inu.jpg",class: "item_pic", alt: "販売写真"
+            = image_tag coach.photos.first.image.to_s,class: "item_pic", alt: "販売写真"
             %span{href:  "#",class: "price",id:"text_price"} 
               =price_split(coach.price)
 
@@ -164,7 +164,7 @@
           =link_to product_path(louisvuitton.id) ,class: "new_item" do
             .item_text 
               =louisvuitton.name
-            = image_tag "inu.jpg",class: "item_pic", alt: "販売写真"
+            = image_tag louisvuitton.photos.first.image.to_s,class: "item_pic", alt: "販売写真"
             %span{href:  "#",class: "price",id:"text_price"} 
               =price_split(louisvuitton.price)
 
@@ -184,7 +184,7 @@
           =link_to product_path(gucci.id) ,class: "new_item" do
             .item_text 
               =gucci.name
-            = image_tag "inu.jpg",class: "item_pic", alt: "販売写真"
+            = image_tag gucci.photos.first.image.to_s,class: "item_pic", alt: "販売写真"
             %span{href:  "#",class: "price",id:"text_price"} 
               =price_split(gucci.price)
 


### PR DESCRIPTION
## what 
- 商品一覧ページにて各商品の写真をDBから参照し、表示できるようにした

- 出品ボタンを商品一覧以外からでも使えるようにした
## why
- 商品一覧をみやすくするため

- 商品出品をしやすくするため

## 確認用GIF
- 商品一覧の写真
https://gyazo.com/a8cc3cac92773fe143014f6a9ccb0aa7
- 出品ボタン
https://gyazo.com/a7a87bb6c7eb0b8706ee0a1a43ff456a