### PR TITLE
メールアドレスのバリデーション

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: [:facebook, :google_oauth2]
+         :recoverable, :rememberable, :omniauthable, omniauth_providers: [:facebook, :google_oauth2]
 
   has_many :products
   has_many :likes
@@ -17,6 +17,7 @@ class User < ApplicationRecord
   validates :last_name, :first_name, :last_name_kana, :first_name_kana, :birthday, presence: true
   validates :nickname, :email, presence: true, uniqueness: true
   validates :password, presence: true, length: { minimum: 7 }
+  validates :email, email_format: true
 
   mount_uploader :image, ImageUploader
 

--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -17,7 +17,7 @@
               = form.label :email, 'メールアドレス'
               %span.l-registration-content__require 必須
               %br/
-              = form.email_field :email, class: "form-input__user", placeholder: "PC・携帯どちらでも可"
+              = form.text_field :email, class: "form-input__user", placeholder: "PC・携帯どちらでも可"
             - if @sns_id.present?
               = hidden_field_tag :sns_auth, true
             - else

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,9 @@ module FreemarketSample66a
     end
     config.i18n.default_locale = :ja
     config.time_zone = 'Tokyo'
+
+    config.autoload_paths += %W[#{config.root}/lib/validators]
+    config.eager_load_paths += %W[#{config.root}/lib/validators]
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -15,7 +15,7 @@ ja:
         current_password: 現在のパスワード
         current_sign_in_at: 現在のログイン時刻
         current_sign_in_ip: 現在のログインIPアドレス
-        email: Eメール
+        email: メールアドレス
         encrypted_password: 暗号化パスワード
         failed_attempts: 失敗したログイン試行回数
         last_sign_in_at: 最終ログイン時刻

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,11 @@
           restrict_dependent_destroy:
             has_one: "%{record}が存在しているので削除できません"
             has_many: "%{record}が存在しているので削除できません"
+        models:
+          user:
+            attributes:
+              email:
+                invalid_email: "は~@~.~の形で入力してください"
     date:
       abbr_day_names:
       - 日

--- a/lib/validators/email_format_validator.rb
+++ b/lib/validators/email_format_validator.rb
@@ -1,0 +1,14 @@
+class EmailFormatValidator < ActiveModel::EachValidator
+  # メールアドレスの@よりも前には、ASCII印字可能文字のうちスペース(\x20)と@(\x40)以外を許可する
+  EMAIL_FORMAT_REGEX = /\A[\x21-\x3f\x41-\x7e]+@(?:[-a-z0-9]+\.)+[a-z]{2,}\z/i
+
+  def validate_each(record, attribute, value)
+    record.errors.add attribute, (options[:message] || :invalid_email) unless valid_email?(value)
+  end
+
+  private
+
+  def valid_email?(email)
+    email =~ EMAIL_FORMAT_REGEX
+  end
+end


### PR DESCRIPTION
# What
- emailのカスタムバリデーションを作成した
- \~@~.~の形でしか登録できないように設定した
- form_withのemail_fieldをtext_fieldに設定した
- deviseのデフォルトのvalidatableを削除した

# Why
- これまでだと~@~の形で登録できるようになっていたため